### PR TITLE
Use mesos env variable for azure dns workaround

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,8 +2,8 @@
 
 #workaround for azure DNS issue
 
-if [ "$EUID" -eq 0 ]
-  then echo -e "\nsearch marathon.l4lb.thisdcos.directory" >> /etc/resolv.conf
+if [ -n "$MESOS_CONTAINER_NAME"  ]; then 
+  echo -e "\nsearch marathon.l4lb.thisdcos.directory" >> /etc/resolv.conf
 fi
 
 #start map server


### PR DESCRIPTION
(Same rationale as in https://github.com/HSLdevcom/OpenTripPlanner/pull/290)

The current workaround for the azure/mesos dns issue, as introduced in 66aec6789a313256f21acfa83ee5e6083f7c5bf9, breaks the dns resolution of this container in other systems like kubernetes.
EUID happens to be 0 there too, but the search domain cannot be used.

This PR changes the way mesos is detected to the MESOS_CONTAINER_NAME env, as it is used in other containers like digitransit-proxy:
https://github.com/HSLdevcom/digitransit-proxy/blob/83c64decb1196d0329d65d369ff35bf99bcf720c/run.sh#L5