### PR TITLE
fix(hsl-map-style): update new glyphs source url

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/HSLdevcom/hsl-map-server#readme",
   "dependencies": {
     "forever": "^0.15.2",
-    "hsl-map-style": "hsldevcom/hsl-map-style#ca06df94c57cdc6aaa68696141879847955b76ea",
+    "hsl-map-style": "hsldevcom/hsl-map-style#b64cdd46046e485b2ffbf4f4890f768b1daf6ad4",
     "mbtiles": "hannesj/node-mbtiles#patch-1",
     "tessera": "^0.12.0",
     "tilejson": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,9 +1400,9 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hsl-map-style@hsldevcom/hsl-map-style#ca06df94c57cdc6aaa68696141879847955b76ea:
+hsl-map-style@hsldevcom/hsl-map-style#b64cdd46046e485b2ffbf4f4890f768b1daf6ad4:
   version "1.0.0"
-  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/ca06df94c57cdc6aaa68696141879847955b76ea"
+  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/b64cdd46046e485b2ffbf4f4890f768b1daf6ad4"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
Update the the commit hash of hsl-map-style to a version where the source URL for glyphs (fonts) is changed from static.hsl.fi to static.hsldev.com.

updated hsl-map-style commit:
https://github.com/HSLdevcom/hsl-map-style/commit/b64cdd46046e485b2ffbf4f4890f768b1daf6ad4