### PR TITLE
hotfix: update deprecated ticket-sales datasource

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/HSLdevcom/hsl-map-server#readme",
   "dependencies": {
     "forever": "^0.15.2",
-    "hsl-map-style": "hsldevcom/hsl-map-style#b64cdd46046e485b2ffbf4f4890f768b1daf6ad4",
+    "hsl-map-style": "hsldevcom/hsl-map-style#0fba8d092af2d51ada3a05e3ada7c57f1b1040c4",
     "mbtiles": "hannesj/node-mbtiles#patch-1",
     "tessera": "^0.12.0",
     "tilejson": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,9 +1400,9 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hsl-map-style@hsldevcom/hsl-map-style#b64cdd46046e485b2ffbf4f4890f768b1daf6ad4:
+hsl-map-style@hsldevcom/hsl-map-style#0fba8d092af2d51ada3a05e3ada7c57f1b1040c4:
   version "1.0.0"
-  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/b64cdd46046e485b2ffbf4f4890f768b1daf6ad4"
+  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/0fba8d092af2d51ada3a05e3ada7c57f1b1040c4"
   dependencies:
     lodash "^4.17.4"
 
@@ -3109,7 +3109,7 @@ tilelive-hsl-parkandride@HSLdevcom/tilelive-hsl-parkandride:
 
 tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales:
   version "0.0.1"
-  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/b9d2b35619cb77f2da7cbff42455a3df24661027"
+  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/38e545c82060428dad66b8363dcbf936cc07bb57"
   dependencies:
     geojson-vt "^2.1.8"
     requestretry "^1.6.0"


### PR DESCRIPTION
Update deprecated tilelive-ticket-sales datasource and hsl-map-style

Old tilelive-hsl-ticket-sales data source in ArcGISonline started returning 404 http://data-hslhrt.opendata.arcgis.com/datasets/21918372164d410683f03925e4441598_0.geojson 

This caused instability in hsl-map-server.

As a quick fix the dataset is mirrored to blob storage: https://hslstoragekarttatuotanto.blob.core.windows.net/map-server-legacy-data/21918372164d410683f03925e4441598_0.geojson