### PR TITLE
update(otp-stops): Add desc field to otp-stops vector tiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#482273fff26f83afc422898dad353f75f753c7ee",
     "tilelive-http": "^0.14.0",
     "tilelive-otp-citybikes": "HSLdevcom/tilelive-otp-citybikes#493589481e96e32928a3f64eb6701ec1650334ff",
-    "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops#3f0cac4ace1b6b506424ea0372c46ab190652914",
+    "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops#cee37855b27a862f2f9eb59e0e938d747466ffd2",
     "tilelive-vector": "^3.9.3",
     "tilelive-xray": "^0.4.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,9 +3146,9 @@ tilelive-otp-routes@HSLdevcom/tilelive-otp-routes:
     requestretry "^1.6.0"
     vt-pbf "^2.0.2"
 
-tilelive-otp-stops@HSLdevcom/tilelive-otp-stops:
+tilelive-otp-stops@HSLdevcom/tilelive-otp-stops#cee37855b27a862f2f9eb59e0e938d747466ffd2:
   version "0.3.3"
-  resolved "https://codeload.github.com/HSLdevcom/tilelive-otp-stops/tar.gz/3f0cac4ace1b6b506424ea0372c46ab190652914"
+  resolved "https://codeload.github.com/HSLdevcom/tilelive-otp-stops/tar.gz/cee37855b27a862f2f9eb59e0e938d747466ffd2"
   dependencies:
     geojson-vt "^2.4.0"
     lodash "^4.15.0"


### PR DESCRIPTION
Update the tilelive-otp-stops dependency. Adds field "desc" to otp-stops vector tiles. The "desc" is shor for desciption and contains the street name or address of the stop. The change is needed for new functionality in digitransit-ui.