### PR TITLE
map-style: road_path visibility to z15

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/HSLdevcom/hsl-map-server#readme",
   "dependencies": {
     "forever": "^0.15.2",
-    "hsl-map-style": "hsldevcom/hsl-map-style#style-update-legacy",
+    "hsl-map-style": "hsldevcom/hsl-map-style#s6485d6f5928e3b9499bf16c643a87ddc17d9e9b9",
     "mbtiles": "hannesj/node-mbtiles#patch-1",
     "tessera": "^0.12.0",
     "tilejson": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/HSLdevcom/hsl-map-server#readme",
   "dependencies": {
     "forever": "^0.15.2",
-    "hsl-map-style": "hsldevcom/hsl-map-style#s6485d6f5928e3b9499bf16c643a87ddc17d9e9b9",
+    "hsl-map-style": "hsldevcom/hsl-map-style#6485d6f5928e3b9499bf16c643a87ddc17d9e9b9",
     "mbtiles": "hannesj/node-mbtiles#patch-1",
     "tessera": "^0.12.0",
     "tilejson": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,9 +1424,9 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hsl-map-style@hsldevcom/hsl-map-style#style-update-legacy:
+hsl-map-style@hsldevcom/hsl-map-style#6485d6f5928e3b9499bf16c643a87ddc17d9e9b9:
   version "1.0.0"
-  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/style-update-legacy"
+  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/6485d6f5928e3b9499bf16c643a87ddc17d9e9b9"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
hsl-map-style update that makes road_path objects to show at the same z15 zoom level as cycleways.