### PR TITLE
update ticket sales point source

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/HSLdevcom/hsl-map-server#readme",
   "dependencies": {
     "forever": "^0.15.2",
-    "hsl-map-style": "hsldevcom/hsl-map-style#e872d922403fa6f597278cbb7ec15a2e085f37ec",
+    "hsl-map-style": "hsldevcom/hsl-map-style#cdc3685a8a4e845c81f19289d1823773b5130ade",
     "mbtiles": "hannesj/node-mbtiles#patch-1",
     "tessera": "^0.12.0",
     "tilejson": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tilejson": "^1.0.1",
     "tilelive-gl": "hsldevcom/tilelive-gl#2f61ec0da7e5b13ca547fa5350905f3c2a688813",
     "tilelive-hsl-parkandride": "HSLdevcom/tilelive-hsl-parkandride",
-    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#c5b4bf6d0f9eebff7aff4d62d07ad439dd243fb9",
+    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#9d304b6c29c9e393df46d01b3a238d48aaa08b69",
     "tilelive-http": "^0.14.0",
     "tilelive-otp-citybikes": "HSLdevcom/tilelive-otp-citybikes#493589481e96e32928a3f64eb6701ec1650334ff",
     "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops#cee37855b27a862f2f9eb59e0e938d747466ffd2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tilejson": "^1.0.1",
     "tilelive-gl": "hsldevcom/tilelive-gl#2f61ec0da7e5b13ca547fa5350905f3c2a688813",
     "tilelive-hsl-parkandride": "HSLdevcom/tilelive-hsl-parkandride",
-    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#482273fff26f83afc422898dad353f75f753c7ee",
+    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#c5b4bf6d0f9eebff7aff4d62d07ad439dd243fb9",
     "tilelive-http": "^0.14.0",
     "tilelive-otp-citybikes": "HSLdevcom/tilelive-otp-citybikes#493589481e96e32928a3f64eb6701ec1650334ff",
     "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops#cee37855b27a862f2f9eb59e0e938d747466ffd2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,9 +1424,9 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hsl-map-style@hsldevcom/hsl-map-style#e872d922403fa6f597278cbb7ec15a2e085f37ec:
+hsl-map-style@hsldevcom/hsl-map-style#cdc3685a8a4e845c81f19289d1823773b5130ade:
   version "1.0.0"
-  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/e872d922403fa6f597278cbb7ec15a2e085f37ec"
+  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/cdc3685a8a4e845c81f19289d1823773b5130ade"
   dependencies:
     lodash "^4.17.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,9 +3164,9 @@ tilelive-hsl-parkandride@HSLdevcom/tilelive-hsl-parkandride:
     requestretry "^1.6.0"
     vt-pbf "^2.0.2"
 
-tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#482273fff26f83afc422898dad353f75f753c7ee:
+tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#c5b4bf6d0f9eebff7aff4d62d07ad439dd243fb9:
   version "0.0.1"
-  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/482273fff26f83afc422898dad353f75f753c7ee"
+  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/c5b4bf6d0f9eebff7aff4d62d07ad439dd243fb9"
   dependencies:
     geojson-vt "^2.1.8"
     requestretry "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,9 +3164,9 @@ tilelive-hsl-parkandride@HSLdevcom/tilelive-hsl-parkandride:
     requestretry "^1.6.0"
     vt-pbf "^2.0.2"
 
-tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#c5b4bf6d0f9eebff7aff4d62d07ad439dd243fb9:
+tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#9d304b6c29c9e393df46d01b3a238d48aaa08b69:
   version "0.0.1"
-  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/c5b4bf6d0f9eebff7aff4d62d07ad439dd243fb9"
+  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/9d304b6c29c9e393df46d01b3a238d48aaa08b69"
   dependencies:
     geojson-vt "^2.1.8"
     requestretry "^1.6.0"


### PR DESCRIPTION
This pull request updates hsl-map-server depency of tilelive-hsl-ticket-sales vector tile data source and corresponding hsl-map-style. The new dataset has a different schema than previous version. 

The new dataset: https://opendata.arcgis.com/datasets/79fe2db71b254edda68c47d2629a962e_0.geojson