### PR TITLE
Make ticket sales point data source loading more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tilejson": "^1.0.1",
     "tilelive-gl": "hsldevcom/tilelive-gl#2f61ec0da7e5b13ca547fa5350905f3c2a688813",
     "tilelive-hsl-parkandride": "HSLdevcom/tilelive-hsl-parkandride",
-    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#9d304b6c29c9e393df46d01b3a238d48aaa08b69",
+    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#49173fb580615b4dc597cbd9e03368f16f8502aa",
     "tilelive-http": "^0.14.0",
     "tilelive-otp-citybikes": "HSLdevcom/tilelive-otp-citybikes#493589481e96e32928a3f64eb6701ec1650334ff",
     "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops#cee37855b27a862f2f9eb59e0e938d747466ffd2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,9 +3164,9 @@ tilelive-hsl-parkandride@HSLdevcom/tilelive-hsl-parkandride:
     requestretry "^1.6.0"
     vt-pbf "^2.0.2"
 
-tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#9d304b6c29c9e393df46d01b3a238d48aaa08b69:
+tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#49173fb580615b4dc597cbd9e03368f16f8502aa:
   version "0.0.1"
-  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/9d304b6c29c9e393df46d01b3a238d48aaa08b69"
+  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/49173fb580615b4dc597cbd9e03368f16f8502aa"
   dependencies:
     geojson-vt "^2.1.8"
     requestretry "^1.6.0"


### PR DESCRIPTION
Dependency update of tilelive-hsl-ticket-sales adds a feature of "cold" local backup dataset for the ticket sales point data source loading. The cold data is used as a last measure if the live AGOL API fails it's retry policy during data loading process. 

Details in pull request: https://github.com/HSLdevcom/tilelive-hsl-ticket-sales/pull/6