### PR TITLE
Revert "Make ticket sales point data source loading more robust"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tilejson": "^1.0.1",
     "tilelive-gl": "hsldevcom/tilelive-gl#2f61ec0da7e5b13ca547fa5350905f3c2a688813",
     "tilelive-hsl-parkandride": "HSLdevcom/tilelive-hsl-parkandride",
-    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#49173fb580615b4dc597cbd9e03368f16f8502aa",
+    "tilelive-hsl-ticket-sales": "HSLdevcom/tilelive-hsl-ticket-sales#9d304b6c29c9e393df46d01b3a238d48aaa08b69",
     "tilelive-http": "^0.14.0",
     "tilelive-otp-citybikes": "HSLdevcom/tilelive-otp-citybikes#493589481e96e32928a3f64eb6701ec1650334ff",
     "tilelive-otp-stops": "HSLdevcom/tilelive-otp-stops#cee37855b27a862f2f9eb59e0e938d747466ffd2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,9 +3164,9 @@ tilelive-hsl-parkandride@HSLdevcom/tilelive-hsl-parkandride:
     requestretry "^1.6.0"
     vt-pbf "^2.0.2"
 
-tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#49173fb580615b4dc597cbd9e03368f16f8502aa:
+tilelive-hsl-ticket-sales@HSLdevcom/tilelive-hsl-ticket-sales#9d304b6c29c9e393df46d01b3a238d48aaa08b69:
   version "0.0.1"
-  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/49173fb580615b4dc597cbd9e03368f16f8502aa"
+  resolved "https://codeload.github.com/HSLdevcom/tilelive-hsl-ticket-sales/tar.gz/9d304b6c29c9e393df46d01b3a238d48aaa08b69"
   dependencies:
     geojson-vt "^2.1.8"
     requestretry "^1.6.0"


### PR DESCRIPTION
Reverts HSLdevcom/hsl-map-server#82

Ticket sales not visible in dev. Testing if this pr was the cause for this